### PR TITLE
Check timestamp before updating frequency in cpp version

### DIFF
--- a/cpp/OneEuroFilter.cpp
+++ b/cpp/OneEuroFilter.cpp
@@ -119,7 +119,7 @@ OneEuroFilter::OneEuroFilter(double freq,
 
 double OneEuroFilter::filter(double value, TimeStamp timestamp) {
   // update the sampling frequency based on timestamps
-  if (lasttime!=UndefinedTime && timestamp!=UndefinedTime)
+  if (lasttime!=UndefinedTime && timestamp!=UndefinedTime && timestamp>lasttime)
     freq = 1.0 / (timestamp-lasttime) ;
   lasttime = timestamp ;
   // estimate the current variation per second 


### PR DESCRIPTION
In some use case, we might encounter that the new timestamp is equal or even smaller than the last timestamp, and it will cause the freq updated incorrectly.